### PR TITLE
Cpp change displacement pair to vector

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,6 +39,6 @@ jobs:
     # Run pytest on the tests directory
     - name: Run tests with pytest
       run: |
-        python -m pip install -e .[test]
+        python -m pip install .[test]
         echo "PYTHONPATH=$(pwd)/src/python" >> $GITHUB_ENV
         python -m pytest ./tests

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -31,4 +31,6 @@ set_target_properties(displacement_calc PROPERTIES
     PREFIX ""
 )
 
-install(TARGETS displacement_calc DESTINATION ${CMAKE_SOURCE_DIR}/src/python/georeferencer)
+install(TARGETS displacement_calc
+    LIBRARY DESTINATION georeferencer
+)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,37 +5,24 @@ project(displacement_calc)
 set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED True)
 
-set(CMAKE_CXX_FLAGS_RELEASE "-O3 -Wall -march=native -flto -ftree-vectorize")
-set(CMAKE_SHARED_LIBRARY_CXX_FLAGS "-fPIC -fopenmp")
-
-set(PYBIND11_FINDPYTHON ON)
+set(CMAKE_SHARED_LIBRARY_CXX_FLAGS "-O3 -Wall -shared -std=c++17 -fPIC -fopenmp -march=native -flto -ftree-vectorize")
 
 if(NOT DEFINED PYBIND11_DIR)
     message(FATAL_ERROR "PYBIND11_DIR is not defined. Set the path to pybind11Config.cmake.")
 endif()
-find_package(pybind11 REQUIRED PATHS ${PYBIND11_DIR} NO_DEFAULT_PATH)
 
-find_package(OpenMP REQUIRED)
+find_package(pybind11 REQUIRED PATHS ${PYBIND11_DIR} NO_DEFAULT_PATH)
 
 set(EIGEN3_INCLUDE_DIR ${CMAKE_SOURCE_DIR}/eigen)
 
 add_library(displacement_calc MODULE src/cpp/displacement_calc.cpp)
 
-target_link_libraries(displacement_calc PRIVATE pybind11::module OpenMP::OpenMP_CXX)
-
+find_package(OpenMP REQUIRED)
+target_link_libraries(displacement_calc PRIVATE OpenMP::OpenMP_CXX)
+target_link_libraries(displacement_calc PRIVATE pybind11::module)
 target_include_directories(displacement_calc PRIVATE ${EIGEN3_INCLUDE_DIR})
 
-if(CMAKE_LIBRARY_OUTPUT_DIRECTORY)
-    set(OUTPUT_DIR "${CMAKE_LIBRARY_OUTPUT_DIRECTORY}/georeferencer")
-else()
-    set(OUTPUT_DIR "${CMAKE_SOURCE_DIR}/src/python/georeferencer")
-endif()
+set_target_properties(displacement_calc PROPERTIES PREFIX "")
 
-set_target_properties(displacement_calc PROPERTIES
-    LIBRARY_OUTPUT_DIRECTORY ${OUTPUT_DIR}
-    PREFIX ""
-)
-
-# Install step (important for packaging)
-install(TARGETS displacement_calc LIBRARY DESTINATION georeferencer)
-
+install(TARGETS displacement_calc
+        LIBRARY DESTINATION georeferencer)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,32 +5,37 @@ project(displacement_calc)
 set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED True)
 
-# Enable optimizations
-set(CMAKE_SHARED_LIBRARY_CXX_FLAGS "-O3 -Wall -shared -std=c++17 -fPIC -fopenmp -march=native -flto -ftree-vectorize")
+set(CMAKE_CXX_FLAGS_RELEASE "-O3 -Wall -march=native -flto -ftree-vectorize")
+set(CMAKE_SHARED_LIBRARY_CXX_FLAGS "-fPIC -fopenmp")
+
+set(PYBIND11_FINDPYTHON ON)
 
 if(NOT DEFINED PYBIND11_DIR)
     message(FATAL_ERROR "PYBIND11_DIR is not defined. Set the path to pybind11Config.cmake.")
 endif()
-
-
-# Find pybind11 using the PYBIND11_DIR path
 find_package(pybind11 REQUIRED PATHS ${PYBIND11_DIR} NO_DEFAULT_PATH)
+
+find_package(OpenMP REQUIRED)
 
 set(EIGEN3_INCLUDE_DIR ${CMAKE_SOURCE_DIR}/eigen)
 
 add_library(displacement_calc MODULE src/cpp/displacement_calc.cpp)
-find_package(OpenMP REQUIRED)
-target_link_libraries(displacement_calc PRIVATE OpenMP::OpenMP_CXX)
 
-# Link pybind11 and Eigen
-target_link_libraries(displacement_calc PRIVATE pybind11::module)
+target_link_libraries(displacement_calc PRIVATE pybind11::module OpenMP::OpenMP_CXX)
+
 target_include_directories(displacement_calc PRIVATE ${EIGEN3_INCLUDE_DIR})
 
+if(CMAKE_LIBRARY_OUTPUT_DIRECTORY)
+    set(OUTPUT_DIR "${CMAKE_LIBRARY_OUTPUT_DIRECTORY}/georeferencer")
+else()
+    set(OUTPUT_DIR "${CMAKE_SOURCE_DIR}/src/python/georeferencer")
+endif()
+
 set_target_properties(displacement_calc PROPERTIES
-    LIBRARY_OUTPUT_DIRECTORY ${CMAKE_SOURCE_DIR}/src/python/georeferencer
+    LIBRARY_OUTPUT_DIRECTORY ${OUTPUT_DIR}
     PREFIX ""
 )
 
-install(TARGETS displacement_calc
-    LIBRARY DESTINATION georeferencer
-)
+# Install step (important for packaging)
+install(TARGETS displacement_calc LIBRARY DESTINATION georeferencer)
+

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -24,5 +24,12 @@ target_include_directories(displacement_calc PRIVATE ${EIGEN3_INCLUDE_DIR})
 
 set_target_properties(displacement_calc PROPERTIES PREFIX "")
 
+add_custom_command(TARGET displacement_calc POST_BUILD
+    COMMAND ${CMAKE_COMMAND} -E copy
+        $<TARGET_FILE:displacement_calc>
+        ${CMAKE_SOURCE_DIR}/src/python/georeferencer/$<TARGET_FILE_NAME:displacement_calc>
+    COMMENT "Copying displacement_calc.so to src/python/georeferencer/"
+)
+
 install(TARGETS displacement_calc
         LIBRARY DESTINATION georeferencer)

--- a/bin/create_reference_image_by_month.py
+++ b/bin/create_reference_image_by_month.py
@@ -1,0 +1,170 @@
+"""Script for creating reference images for georeferencer."""
+
+import logging
+import subprocess
+import sys
+from pathlib import Path
+
+import cv2
+import requests
+
+# Setup logging
+logging.basicConfig(level=logging.INFO, format="%(asctime)s - %(levelname)s - %(message)s")
+logger = logging.getLogger(__name__)
+
+TILES = {
+    "A1": (90.0, -180.0),
+    "B1": (90.0, -90.0),
+    "C1": (90.0, 0.0),
+    "D1": (90.0, 90.0),
+    "A2": (0.0, -180.0),
+    "B2": (0.0, -90.0),
+    "C2": (0.0, 0.0),
+    "D2": (0.0, 90.0),
+}
+
+BASE_URL = "https://neo.gsfc.nasa.gov/archive/bluemarble/bmng/world_500m"
+OCEANMASK_TILES_URL = "https://neo.gsfc.nasa.gov/archive/bluemarble/bmng/landmask/world.oceanmask.21600x21600."
+OCEANMASK_EXTENSION = ".png"
+
+RESOLUTION = 1 / 240
+
+
+def download_file(url, path):
+    """Downloads file."""
+    if not path.exists():
+        logger.info(f"Downloading {url}...")
+        r = requests.get(url, stream=True)
+        if r.status_code == 200:
+            with open(path, "wb") as f:
+                for chunk in r.iter_content(1024 * 1024):
+                    f.write(chunk)
+            logger.info(f"Downloaded to {path}")
+        else:
+            raise RuntimeError(f"Failed to download: {url} — HTTP {r.status_code}")
+    else:
+        logger.info(f"Already exists: {path}")
+
+
+def download_tile_png(month, tile, dest_dir):
+    """Downloads tile for specific month and tile number."""
+    filename = f"world.topo.2004{month:02d}.3x21600x21600.{tile}.png"
+    url = f"{BASE_URL}/{filename}"
+    path = dest_dir / filename
+    download_file(url, path)
+    return path
+
+
+def download_tile_ocean_mask(tile, dest_dir):
+    """Downloads ocean mask for specific month and tile."""
+    filename = f"world.oceanmask.21600x21600.{tile}.png"
+    url = f"{OCEANMASK_TILES_URL}{tile}{OCEANMASK_EXTENSION}"
+    path = dest_dir / filename
+    download_file(url, path)
+    return path
+
+
+def apply_mask_and_convert_to_tif(tile_png, ocean_mask_png, output_tif, tile_key):
+    """Applies ocean mask png to tile png."""
+    if Path(output_tif).exists():
+        logger.info(f"{output_tif} already exists. Skipping.")
+        return
+
+    logger.info(f"Masking and converting {tile_png} to {output_tif}...")
+
+    img = cv2.imread(str(tile_png))
+    mask = cv2.imread(str(ocean_mask_png), cv2.IMREAD_GRAYSCALE)
+
+    if img is None or mask is None:
+        raise ValueError(f"Failed to load image or mask for tile {tile_png}")
+
+    masked = cv2.bitwise_and(img, img, mask=mask)
+
+    masked_png = Path(output_tif).with_suffix(".masked.png")
+    cv2.imwrite(str(masked_png), masked)
+
+    ul_lat, ul_lon = TILES[tile_key]
+
+    cmd = [
+        "gdal_translate",
+        "-of",
+        "GTiff",
+        "-a_ullr",
+        str(ul_lon),
+        str(ul_lat),
+        str(ul_lon + 90),
+        str(ul_lat - 90),
+        "-a_srs",
+        "EPSG:4326",
+        "-co",
+        "BIGTIFF=YES",
+        str(masked_png),
+        str(output_tif),
+    ]
+
+    subprocess.run(cmd, check=True)
+    masked_png.unlink()
+
+    logger.info(f"Saved masked GeoTIFF to {output_tif}")
+
+
+def merge_tiles(tiles, output_file):
+    """Merge geotiff files."""
+    logger.info("Merging tiles with GDAL Merge (gdal_merge.py)...")
+
+    cmd = [
+        "gdal_merge.py",
+        "-o",
+        output_file,
+        "-of",
+        "GTiff",
+        "-co",
+        "COMPRESS=ZSTD",
+        "-co",
+        "ZSTD_LEVEL=6",
+        "-co",
+        "TILED=YES",
+        "-co",
+        "BIGTIFF=YES",
+    ] + [str(tile) for tile in tiles]
+
+    subprocess.run(cmd, check=True)
+    logger.info(f"Merged output: {output_file}")
+
+
+def create_tif(month):
+    """Create geotiff file."""
+    dest_dir = Path("bmng_tiles")
+    dest_dir.mkdir(exist_ok=True)
+
+    masked_tifs = []
+
+    for tile in TILES:
+        tile_png = download_tile_png(month, tile, dest_dir)
+        mask_png = download_tile_ocean_mask(tile, dest_dir)
+
+        masked_tif = dest_dir / f"{tile}_{month}_masked.tif"
+        apply_mask_and_convert_to_tif(tile_png, mask_png, masked_tif, tile)
+
+        masked_tifs.append(masked_tif)
+
+    output_file = f"geo_reference_2004{month:02d}.tif"
+    merge_tiles(masked_tifs, output_file)
+    return output_file
+
+
+if __name__ == "__main__":
+    if len(sys.argv) != 2:
+        logger.error("Usage: python create_reference_image_by_month.py <month (1–12)>")
+        sys.exit(1)
+
+    try:
+        month = int(sys.argv[1])
+        if not (1 <= month <= 12):
+            raise ValueError
+    except ValueError:
+        logger.error("Please provide a valid month number between 1 and 12.")
+        sys.exit(1)
+
+    merged_tif = create_tif(month)
+    logger.info(f"Final merged and masked TIFF saved to {merged_tif}")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,11 +38,12 @@ intel = [
 
 [tool.setuptools]
 package-dir = {"" = "src/python"}
-
-[tool.setuptools_scm]
+include-package-data = true
 
 [tool.setuptools.package-data]
 "georeferencer" = ["*.so"]
+
+[tool.setuptools_scm]
 
 [tool.isort]
 sections = ["FUTURE", "STDLIB", "THIRDPARTY", "FIRSTPARTY", "LOCALFOLDER"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,6 +41,9 @@ package-dir = {"" = "src/python"}
 
 [tool.setuptools_scm]
 
+[tool.setuptools.package-data]
+"georeferencer" = ["*.so"]
+
 [tool.isort]
 sections = ["FUTURE", "STDLIB", "THIRDPARTY", "FIRSTPARTY", "LOCALFOLDER"]
 profile = "black"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,6 +22,7 @@ dependencies = [
     "pyresample>=1.33.0",
     "rioxarray>=0.18.2",
     "scipy>=1.15.2",
+    "pyorbital>1.10.0",
 ]
 
 [project.optional-dependencies]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,7 @@ dependencies = [
     "pyresample>=1.33.0",
     "rioxarray>=0.18.2",
     "scipy>=1.15.2",
-    "pyorbital>=1.10.0",
+    "pyorbital>1.10.0",
 ]
 
 [project.optional-dependencies]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ dynamic = ["version"]
 description = "Python package for georeferencing satellite imagery."
 readme = "README.md"
 authors = [
-    { name = "Jacob Nilsson"},
+    { name = "Jacob Nilsson", email = "jacobnilsson95@hotmail.com" },
     { name = "Martin Raspaud", email = "martin.raspaud@smhi.se" },
 ]
 requires-python = ">=3.11"
@@ -22,7 +22,7 @@ dependencies = [
     "pyresample>=1.33.0",
     "rioxarray>=0.18.2",
     "scipy>=1.15.2",
-    "pyorbital>1.10.0",
+    "pyorbital>=1.10.0",
 ]
 
 [project.optional-dependencies]

--- a/setup.py
+++ b/setup.py
@@ -52,6 +52,7 @@ class CMakeBuildExt(build_ext_orig):
             ]
         )
         subprocess.check_call(["cmake", "--build", build_temp])
+        subprocess.check_call(["cmake", "--install", build_temp])
         ext_build_lib = os.path.abspath(self.build_lib)
         target_dir = os.path.join(ext_build_lib, "georeferencer")
         os.makedirs(target_dir, exist_ok=True)

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,6 @@
 """Setup for georeferencer module."""
 
 import os
-import shutil
 import subprocess
 
 from setuptools import Extension, setup
@@ -25,8 +24,8 @@ class CMakeBuildExt(build_ext_orig):
         if not os.path.exists(eigen_dir):
             os.makedirs(eigen_dir, exist_ok=True)
             subprocess.run(
-                "curl -L https://gitlab.com/libeigen/eigen/-/archive/3.4.0/eigen-3.4.0.tar.gz "
-                "| tar xz --strip-components=1 -C eigen",
+                "curl -L https://gitlab.com/libeigen/eigen/-/archive/3.4.0/eigen-3.4.0.tar.gz \
+                    | tar xz --strip-components=1 -C eigen",
                 shell=True,
                 check=True,
             )
@@ -43,22 +42,17 @@ class CMakeBuildExt(build_ext_orig):
             [
                 "cmake",
                 "-DCMAKE_BUILD_TYPE=Release",
-                f"-DCMAKE_LIBRARY_OUTPUT_DIRECTORY={build_temp}",
-                f"-DPYBIND11_DIR={pybind11_dir}",
                 "-S",
                 ".",
                 "-B",
                 build_temp,
+                f"-DPYBIND11_DIR={pybind11_dir}",
+                f"-DCMAKE_INSTALL_PREFIX={os.path.abspath(self.build_lib)}",
             ]
         )
+
         subprocess.check_call(["cmake", "--build", build_temp])
         subprocess.check_call(["cmake", "--install", build_temp])
-        ext_build_lib = os.path.abspath(self.build_lib)
-        target_dir = os.path.join(ext_build_lib, "georeferencer")
-        os.makedirs(target_dir, exist_ok=True)
-
-        built_lib = os.path.join(build_temp, "displacement_calc.so")
-        shutil.copy(built_lib, target_dir)
 
 
 setup(

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,7 @@
 """Setup for georeferencer module."""
 
 import os
+import shutil
 import subprocess
 
 from setuptools import Extension, setup
@@ -53,6 +54,17 @@ class CMakeBuildExt(build_ext_orig):
 
         subprocess.check_call(["cmake", "--build", build_temp])
         subprocess.check_call(["cmake", "--install", build_temp])
+
+        so_dst = os.path.join(self.build_lib, "georeferencer", "displacement_calc.so")
+
+        if not os.path.exists(so_dst) and os.path.exists(
+            os.path.join(build_temp, "georeferencer", "displacement_calc.so")
+        ):
+            os.makedirs(os.path.dirname(so_dst), exist_ok=True)
+            shutil.copyfile(
+                os.path.join(build_temp, "georeferencer", "displacement_calc.so"),
+                so_dst,
+            )
 
 
 setup(

--- a/src/cpp/displacement_calc.cpp
+++ b/src/cpp/displacement_calc.cpp
@@ -310,14 +310,10 @@ std::vector<std::tuple<float, float>> calculate_covariance_displacement(const st
                 y0 -= max_displacement;
                 x0 = std::round(x0 * 10.0f) / 10.0f;
                 y0 = std::round(y0 * 10.0f) / 10.0f;
-                displacements[i] = {y0, x0};
+                if (std::abs(y0) < max_displacement && std::abs(x0) < max_displacement)
+                    displacements[i] = {y0, x0};
             }
         }
-    }
-    for (auto &d : displacements)
-    {
-        if (std::abs(std::get<0>(d)) >= max_displacement || std::abs(std::get<1>(d)) >= max_displacement)
-            d = {-100.0f, -100.0f};
     }
     return displacements;
 }

--- a/src/cpp/displacement_calc.cpp
+++ b/src/cpp/displacement_calc.cpp
@@ -303,7 +303,7 @@ std::vector<std::tuple<float, float>> calculate_covariance_displacement(const st
             float CL = !circumference_values.empty() ? *std::max_element(circumference_values.begin(), circumference_values.end()) : 0;
 
             float score = mean_cov + CL;
-            if (score < 237)
+            if (score < 240)
             {
                 auto [x0, y0] = subpixel_maximum(res, dy, dx);
                 x0 -= max_displacement;

--- a/src/python/georeferencer/georeferencer.py
+++ b/src/python/georeferencer/georeferencer.py
@@ -76,8 +76,8 @@ def gcp_to_lonlat(gcp_x, gcp_y, geo_transform):
     Returns:
         tuple: (longitude, latitude) of the GCP in geographic coordinates.
     """
-    gcp_x_original = (gcp_x + 3) * 16
-    gcp_y_original = (gcp_y + 3) * 16
+    gcp_x_original = (gcp_x) * 16
+    gcp_y_original = (gcp_y) * 16
 
     xp, yp = xy(geo_transform, gcp_y_original, gcp_x_original)
 

--- a/src/python/georeferencer/georeferencer.py
+++ b/src/python/georeferencer/georeferencer.py
@@ -341,7 +341,7 @@ def get_swath_displacement(calibrated_ds, sun_zen, reference_image_path):
         valid_gcp_lonlats[:, 1],
         calibrated_ds["times"][0].values,
         calibrated_ds.attrs["tle"],
-        55.37,
+        calibrated_ds.attrs["max_scan_angle"],
     )
 
 

--- a/src/python/georeferencer/georeferencer.py
+++ b/src/python/georeferencer/georeferencer.py
@@ -238,11 +238,11 @@ def get_swath_displacement(calibrated_ds, sun_zen, reference_image_path):
     Raises:
         ValueError: If no valid displacement is found.
     """
-    swath = calibrated_ds.sel(channel_name="2").channels.data
+    swath = calibrated_ds.sel(channel_name="2").channels.data / np.cos(np.deg2rad(sun_zen))
     night_swath = calibrated_ds.sel(channel_name="4").channels.data
     max_val = np.nanmax(night_swath)
     night_swath = max_val - night_swath
-    swath = np.where(sun_zen >= 90, night_swath, swath)
+    swath = np.where(sun_zen >= 87, night_swath, swath)
 
     swath_longitudes = calibrated_ds["longitude"]
     swath_latitudes = calibrated_ds["latitude"]

--- a/tests/test_displacement_calc.py
+++ b/tests/test_displacement_calc.py
@@ -1,7 +1,11 @@
 """Tests for displacement_calc library."""
 
+import math
+from pathlib import Path
+
 import georeferencer.displacement_calc as dc
 import numpy as np
+from scipy.ndimage import gaussian_filter
 
 
 def generate_synthetic_data(size, dy, dx):
@@ -65,7 +69,10 @@ def test_covariance_displacement():
 
     displacement = dc.calculate_covariance_displacement(points, swath_P, ref_Q, 48, 24)
 
-    assert displacement == (-23, 23), f"Expected (-23, 23) displacement, got {displacement}"
+    tol = 1e-1
+    for i, (dy, dx) in enumerate(displacement):
+        assert math.isclose(dy, -23.0, abs_tol=tol), f"displacement[{i}].dy = {dy:.3e} exceeds ±{tol}"
+        assert math.isclose(dx, 23.0, abs_tol=tol), f"displacement[{i}].dx = {dx:.3e} exceeds ±{tol}"
 
 
 def test_covariance_displacement_no_displacement():
@@ -79,7 +86,10 @@ def test_covariance_displacement_no_displacement():
 
     displacement = dc.calculate_covariance_displacement(points, swath_P, ref_Q, 48, 24)
 
-    assert displacement == (0, 0), f"Expected (0, 0) displacement, got {displacement}"
+    tol = 1e-4
+    for i, (dy, dx) in enumerate(displacement):
+        assert math.isclose(dy, 0.0, abs_tol=tol), f"displacement[{i}].dy = {dy:.3e} exceeds ±{tol}"
+        assert math.isclose(dx, 0.0, abs_tol=tol), f"displacement[{i}].dx = {dx:.3e} exceeds ±{tol}"
 
 
 def test_covariance_displacement_with_too_large_displacement():
@@ -93,4 +103,176 @@ def test_covariance_displacement_with_too_large_displacement():
 
     displacement = dc.calculate_covariance_displacement(points, swath_P, ref_Q, 48, 24)
 
-    assert displacement == (-100, -100), f"Expected (-100, -100) displacement, got {displacement}"
+    for i, (dy, dx) in enumerate(displacement):
+        assert math.isclose(dy, np.float32(-100.0), abs_tol=0), f"displacement[{i}].dy = {dy:.3e}"
+        assert math.isclose(dx, np.float32(-100.0), abs_tol=0), f"displacement[{i}].dx = {dx:.3e}"
+
+
+def downsample_mean(img: np.ndarray, factor: int):
+    """Downsample image by averaging over non-overlapping blocks of shape (factor x factor)."""
+    H, W = img.shape
+    reshaped = img[: H // factor * factor, : W // factor * factor]
+    reshaped = reshaped.reshape(H // factor, factor, W // factor, factor)
+    down = reshaped.mean(axis=(1, 3))
+    return down
+
+
+def downsample_mean_offset(img: np.ndarray, factor: int, dy: float, dx: float):
+    """Downsample the image with an offset applied before averaging."""
+    oy = int(round(dy * factor))
+    ox = int(round(dx * factor))
+    H, W = img.shape
+    H_crop = (H - oy) // factor * factor
+    W_crop = (W - ox) // factor * factor
+    sub = img[oy : oy + H_crop, ox : ox + W_crop]
+    return downsample_mean(sub, factor)
+
+
+def get_or_create_test_image(path: Path, shape=(10000, 10000), min_val=0.0, max_val=255.0, seed=42, add_pattern=True):
+    """Load an image from disk if it exists, or create and save a random structured image."""
+    path.parent.mkdir(parents=True, exist_ok=True)
+    if path.exists():
+        return np.load(path)
+
+    rng = np.random.default_rng(seed)
+    img = rng.uniform(min_val, max_val, size=shape).astype(np.float32)
+
+    if add_pattern:
+        y = np.linspace(0, 10 * np.pi, shape[0], dtype=np.float32)
+        x = np.linspace(0, 10 * np.pi, shape[1], dtype=np.float32)
+        X, Y = np.meshgrid(x, y)
+        pattern = 50 * np.sin(X) * np.cos(Y)
+        img += pattern.astype(np.float32)
+
+    img = gaussian_filter(img, sigma=2)
+
+    img = (img - img.min()) / (img.max() - img.min()) * (max_val - min_val) + min_val
+
+    np.save(path, img)
+    return img
+
+
+def test_sub_pixel_calculations_A():
+    """Test sub pixel calculations with two low value decimals."""
+    img_file = Path(__file__).parent / "test_img.npy"
+    img = get_or_create_test_image(img_file)
+    F = 10
+
+    shift_A = (0.0, 0.0)
+    shift_B = (5.2, 3.1)
+
+    A = downsample_mean_offset(img, F, *shift_A)
+    B = downsample_mean_offset(img, F, *shift_B)
+
+    points = [(250, 250), (200, 250), (400, 400), (100, 100), (100, 250), (50, 70), (60, 95)]
+
+    displacement = dc.calculate_covariance_displacement(points, B, A, 48, 24)
+    tol = 0.3
+    for i, (dy, dx) in enumerate(displacement):
+        assert math.isclose(dy, shift_B[0], abs_tol=tol), f"displacement[{i}].dy = {dy:.3e} exceeds ±{tol}"
+        assert math.isclose(dx, shift_B[1], abs_tol=tol), f"displacement[{i}].dx = {dx:.3e} exceeds ±{tol}"
+
+
+def test_sub_pixel_calculations_B():
+    """Test sub pixel calculations with one low and one high value decimal."""
+    img_file = Path(__file__).parent / "test_img.npy"
+    img = get_or_create_test_image(img_file)
+    F = 10
+
+    shift_A = (0.0, 0.0)
+    shift_B = (3.2, 1.8)
+
+    A = downsample_mean_offset(img, F, *shift_A)
+    B = downsample_mean_offset(img, F, *shift_B)
+
+    points = [(250, 250), (200, 250), (400, 400), (100, 100), (100, 250), (50, 70), (60, 95)]
+
+    displacement = dc.calculate_covariance_displacement(points, B, A, 48, 24)
+    tol = 0.3
+    for i, (dy, dx) in enumerate(displacement):
+        assert math.isclose(dy, shift_B[0], abs_tol=tol), f"displacement[{i}].dy = {dy:.3e} exceeds ±{tol}"
+        assert math.isclose(dx, shift_B[1], abs_tol=tol), f"displacement[{i}].dx = {dx:.3e} exceeds ±{tol}"
+
+
+def test_sub_pixel_calculations_C():
+    """Test sub pixel calculations with one high and one low value decimal."""
+    img_file = Path(__file__).parent / "test_img.npy"
+    img = get_or_create_test_image(img_file)
+    F = 10
+
+    shift_A = (0.0, 0.0)
+    shift_B = (7.9, 2.2)
+
+    A = downsample_mean_offset(img, F, *shift_A)
+    B = downsample_mean_offset(img, F, *shift_B)
+
+    points = [(250, 250), (200, 250), (400, 400), (100, 100), (100, 250), (50, 70), (60, 95)]
+
+    displacement = dc.calculate_covariance_displacement(points, B, A, 48, 24)
+    tol = 0.3
+    for i, (dy, dx) in enumerate(displacement):
+        assert math.isclose(dy, shift_B[0], abs_tol=tol), f"displacement[{i}].dy = {dy:.3e} exceeds ±{tol}"
+        assert math.isclose(dx, shift_B[1], abs_tol=tol), f"displacement[{i}].dx = {dx:.3e} exceeds ±{tol}"
+
+
+def test_sub_pixel_calculations_D():
+    """Test sub pixel calculations with two high value decimal."""
+    img_file = Path(__file__).parent / "test_img.npy"
+    img = get_or_create_test_image(img_file)
+    F = 10
+
+    shift_A = (0.0, 0.0)
+    shift_B = (5.8, 6.9)
+
+    A = downsample_mean_offset(img, F, *shift_A)
+    B = downsample_mean_offset(img, F, *shift_B)
+
+    points = [(250, 250), (200, 250), (400, 400), (100, 100), (100, 250), (50, 70), (60, 95)]
+
+    displacement = dc.calculate_covariance_displacement(points, B, A, 48, 24)
+    tol = 0.3
+    for i, (dy, dx) in enumerate(displacement):
+        assert math.isclose(dy, shift_B[0], abs_tol=tol), f"displacement[{i}].dy = {dy:.3e} exceeds ±{tol}"
+        assert math.isclose(dx, shift_B[1], abs_tol=tol), f"displacement[{i}].dx = {dx:.3e} exceeds ±{tol}"
+
+
+def test_sub_pixel_calculations_E():
+    """Test sub pixel calculations with two mid range value decimal."""
+    img_file = Path(__file__).parent / "test_img.npy"
+    img = get_or_create_test_image(img_file)
+    F = 10
+
+    shift_A = (0.0, 0.0)
+    shift_B = (5.7, 6.3)
+
+    A = downsample_mean_offset(img, F, *shift_A)
+    B = downsample_mean_offset(img, F, *shift_B)
+
+    points = [(250, 250), (200, 250), (400, 400), (100, 100), (100, 250), (50, 70), (60, 95)]
+
+    displacement = dc.calculate_covariance_displacement(points, B, A, 48, 24)
+    tol = 0.3
+    for i, (dy, dx) in enumerate(displacement):
+        assert math.isclose(dy, shift_B[0], abs_tol=tol), f"displacement[{i}].dy = {dy:.3e} exceeds ±{tol}"
+        assert math.isclose(dx, shift_B[1], abs_tol=tol), f"displacement[{i}].dx = {dx:.3e} exceeds ±{tol}"
+
+
+def test_sub_pixel_calculations_F():
+    """Test sub pixel calculations with two mid range value decimal."""
+    img_file = Path(__file__).parent / "test_img.npy"
+    img = get_or_create_test_image(img_file)
+    F = 10
+
+    shift_A = (0.0, 0.0)
+    shift_B = (5.4, 6.7)
+
+    A = downsample_mean_offset(img, F, *shift_A)
+    B = downsample_mean_offset(img, F, *shift_B)
+
+    points = [(250, 250), (200, 250), (400, 400), (100, 100), (100, 250), (50, 70), (60, 95)]
+
+    displacement = dc.calculate_covariance_displacement(points, B, A, 48, 24)
+    tol = 0.3
+    for i, (dy, dx) in enumerate(displacement):
+        assert math.isclose(dy, shift_B[0], abs_tol=tol), f"displacement[{i}].dy = {dy:.3e} exceeds ±{tol}"
+        assert math.isclose(dx, shift_B[1], abs_tol=tol), f"displacement[{i}].dx = {dx:.3e} exceeds ±{tol}"


### PR DESCRIPTION
Changed `calculate_covariance_displacement` return from a single displacement to a vector of displacements with the same indices as the GCP coordinates. This simplifies the comparison of each GCP and what displacement is calculated from it.